### PR TITLE
TiledError handling

### DIFF
--- a/deucalion-rs/Cargo.lock
+++ b/deucalion-rs/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "hlua 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sfml 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiled 0.1.5 (git+https://github.com/team-code/rs-tiled.git)",
+ "tiled 0.1.5 (git+https://github.com/mattyhall/rs-tiled.git)",
 ]
 
 [[package]]
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 name = "tiled"
 version = "0.1.5"
-source = "git+https://github.com/team-code/rs-tiled.git#2e2f11dd68b5b94470193bb019deda6202619698"
+source = "git+https://github.com/mattyhall/rs-tiled.git#64e2472d5c4c64f672c57c80d802426198d7ac5a"
 dependencies = [
  "base64 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/deucalion-rs/Cargo.lock
+++ b/deucalion-rs/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "hlua 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sfml 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiled 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiled 0.1.5 (git+https://github.com/team-code/rs-tiled.git)",
 ]
 
 [[package]]
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 name = "tiled"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/team-code/rs-tiled.git#2e2f11dd68b5b94470193bb019deda6202619698"
 dependencies = [
  "base64 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/deucalion-rs/Cargo.toml
+++ b/deucalion-rs/Cargo.toml
@@ -8,4 +8,4 @@ hlua = "*"
 sfml = "0.11.2"
 log = "*"
 env_logger = "*"
-tiled = "*"
+tiled = { git = "https://github.com/team-code/rs-tiled.git" }

--- a/deucalion-rs/Cargo.toml
+++ b/deucalion-rs/Cargo.toml
@@ -8,4 +8,4 @@ hlua = "*"
 sfml = "0.11.2"
 log = "*"
 env_logger = "*"
-tiled = { git = "https://github.com/team-code/rs-tiled.git" }
+tiled = { git = "https://github.com/mattyhall/rs-tiled.git" }

--- a/deucalion-rs/src/error.rs
+++ b/deucalion-rs/src/error.rs
@@ -5,11 +5,13 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 use hlua;
+use tiled;
 
 #[derive(Debug)]
 pub enum DeucalionError {
     IoError(io::Error),
     LuaError(hlua::LuaError),
+    TiledError(tiled::TiledError),
     OtherError(String),
 }
 
@@ -43,6 +45,7 @@ impl Error for DeucalionError {
         match *self {
             DeucalionError::IoError(ref err) => err.description(),
             DeucalionError::LuaError(_) => "There was an error in Lua code.",
+            DeucalionError::TiledError(ref err) => err.description(),
             DeucalionError::OtherError(ref string) => string.as_ref(),
         }
     }
@@ -52,6 +55,8 @@ impl Error for DeucalionError {
             // LuaError doesn't currently implement Error. If it ever does,
             //  this can be changed to be more useful.
             DeucalionError::LuaError(_) => None,
+            // TiledError currently doesn't implement Error.
+            DeucalionError::TiledError(ref err) => Some(err as &Error),
             DeucalionError::OtherError(_) => None,
         }
     }
@@ -64,6 +69,7 @@ impl fmt::Display for DeucalionError {
             // Currently, LuaError doesn't implement Display. If it ever does,
             //  this can be changed in order to be more useful
             DeucalionError::LuaError(_) => Err(fmt::Error),
+            DeucalionError::TiledError(ref err) => fmt::Display::fmt(err, f),
             DeucalionError::OtherError(ref string) => fmt::Display::fmt(string, f),
         }
     }

--- a/deucalion-rs/src/main.rs
+++ b/deucalion-rs/src/main.rs
@@ -5,6 +5,7 @@ extern crate sfml;
 extern crate log;
 extern crate env_logger;
 extern crate hlua;
+extern crate tiled;
 
 use sfml::window::{ContextSettings, VideoMode, window_style};
 use sfml::window::event;


### PR DESCRIPTION
Allows the DeucalionError type to encapsulate TiledError, the error encapsulation used by the Tiled tilemap library. Important progress toward #1 and #11
